### PR TITLE
docs(http): Update the Setup for testing in Http Client

### DIFF
--- a/adev/src/content/guide/http/testing.md
+++ b/adev/src/content/guide/http/testing.md
@@ -8,12 +8,13 @@ At the end, tests can verify that the app made no unexpected requests.
 
 ## Setup for testing
 
-To begin testing usage of `HttpClient`, configure `TestBed` and include `provideHttpClientTesting` in your test's setup. This configures `HttpClient` to use a test backend instead of the real network. It also provides `HttpTestingController`, which you'll use to interact with the test backend, set expectations about which requests have been made, and flush responses to those requests. `HttpTestingController` can be injected from `TestBed` once configured.
+To begin testing usage of `HttpClient`, configure `TestBed` and include `provideHttpClient()` and `provideHttpClientTesting` in your test's setup. This configures `HttpClient` to use a test backend instead of the real network. It also provides `HttpTestingController`, which you'll use to interact with the test backend, set expectations about which requests have been made, and flush responses to those requests. `HttpTestingController` can be injected from `TestBed` once configured.
 
 <docs-code language="ts">
 TestBed.configureTestingModule({
   providers: [
     // ... other test providers
+    provideHttpClient(),
     provideHttpClientTesting(),
   ],
 });
@@ -31,6 +32,7 @@ For example, you can write a test that expects a GET request to occur and provid
 TestBed.configureTestingModule({
   providers: [
     ConfigService,
+    provideHttpClient(),
     provideHttpClientTesting(),
   ],
 });


### PR DESCRIPTION
docs(http): Update the Setup for testing in Http Client to include provideHttpClient()

It is not enough to use provideHttpClientTesting() for HTTP Client Testing, it will throw a dependency injection error. Update the docs to include both provideHttpClient() and provideHttpClientTesting()

Fixes #53390

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Docs says use provideHttpClientTesting() for HTTP Client Testing, but it will throw a dependency injection error.

Issue Number: #53390


## What is the new behavior?
Docs says include both provideHttpClient() and provideHttpClientTesting() for HTTP Client Testing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
